### PR TITLE
iPhone 6 and 6+, add raw string to unknown

### DIFF
--- a/UIDevice+HardwareModel.h
+++ b/UIDevice+HardwareModel.h
@@ -1,7 +1,7 @@
 //
 //  UIDevice+HardwareModel.h
 //
-//  Created by Heiko Dreyer on 11.05.11.
+//  Created by Heiko Dreyer on 05/11/11.
 //  Copyright 2011 boxedfolder.com. All rights reserved.
 //
 
@@ -9,6 +9,7 @@
 
 typedef enum __UIHardwareModel
 {
+    UIHardwareModelUnknown = 0,
 	UIHardwareModelSimulator = 1,
     
 	UIHardwareModeliPhone1G = 2,
@@ -49,7 +50,10 @@ typedef enum __UIHardwareModel
     UIHardwareModeliPhone5cGlobal = 29,
     
 	UIHardwareModeliPhone5s = 30,
-    UIHardwareModeliPhone5sGlobal = 31
+    UIHardwareModeliPhone5sGlobal = 31,
+    
+    UIHardwareModeliPhone6 = 32,
+    UIHardwareModeliPhone6Plus = 33
     
 } UIHardwareModel;
 

--- a/UIDevice+HardwareModel.h
+++ b/UIDevice+HardwareModel.h
@@ -7,9 +7,10 @@
 
 #import <UIKit/UIKit.h>
 
-typedef enum __UIHardwareModel
+typedef NS_ENUM(NSInteger, UIHardwareModel)
 {
     UIHardwareModelUnknown = 0,
+    
 	UIHardwareModelSimulator = 1,
     
 	UIHardwareModeliPhone1G = 2,
@@ -55,7 +56,7 @@ typedef enum __UIHardwareModel
     UIHardwareModeliPhone6 = 32,
     UIHardwareModeliPhone6Plus = 33
     
-} UIHardwareModel;
+};
 
 @interface UIDevice (HardwareModel) 
 

--- a/UIDevice+HardwareModel.m
+++ b/UIDevice+HardwareModel.m
@@ -1,7 +1,7 @@
 //
 //  UIDevice+HardwareModel.m
 //
-//  Created by Heiko Dreyer on 11.05.11.
+//  Created by Heiko Dreyer on 05/11/11.
 //  Copyright 2011 boxedfolder.com. All rights reserved.
 //
 
@@ -131,6 +131,8 @@
 		
 		NSString *hwString = [NSString stringWithCString: model encoding: NSUTF8StringEncoding];
 		free(model);
+        
+        _hardwareModel = UIHardwareModelUnknown; // Unknown by default
 		
 		if([hwString isEqualToString: @"i386"] || [hwString isEqualToString:@"x86_64"])   
 			_hardwareModel = UIHardwareModelSimulator;
@@ -227,6 +229,12 @@
 			
 		if([hwString isEqualToString: @"iPad3,6"])
 			_hardwareModel = UIHardwareModeliPad4CDMA;
+            
+        if([hwString isEqualToString: @"iPhone7,1"])
+            _hardwareModel = UIHardwareModeliPhone6Plus;
+        
+        if([hwString isEqualToString: @"iPhone7,2"])
+            _hardwareModel = UIHardwareModeliPhone6;
 	}
 	
 	return _hardwareModel;


### PR DESCRIPTION
Hey.

Instead of just `@"Unknown"` it seems a bit more useful to have something like `@"Unknown - iPhone8,1"` as the human readable name. That way if you are using this for analytics (like I am) you can see all the devices, even if this library doesn't know what they are yet.

I've also included Heiko's commit for iphone 6 and 6+ - this is a cherry-pick of his commit so it shouldn't conflict with anything else he's done or a pull request from him :)

Let me know what you think,
Sam
